### PR TITLE
fix: User appears in their own "People you may know" section #167

### DIFF
--- a/backend/workshare/views.py
+++ b/backend/workshare/views.py
@@ -518,7 +518,7 @@ def getPossibleConnectionsView(request, pk):
         if connection.sender_id not in connection_list:
             connection_list.append(connection.sender_id)
 
-    possibleConnections = User.objects.all().exclude(id__in=connection_list)
+    possibleConnections = User.objects.all().exclude(Q(id__in=connection_list) | Q(id=pk))
 
     if possibleConnections.count() >= 5:
         possibleConnections = possibleConnections[:5]


### PR DESCRIPTION
This pull request fixes the bug mentioned in #167.

The list of possible connections was being determined through the user's existing connections, but did not account for the case where a user has no connections.

If merged, this pull request resolves #167.