### PR TITLE
Fix: after registration, profile name is saved as email address

### DIFF
--- a/backend/workshare/signals.py
+++ b/backend/workshare/signals.py
@@ -11,7 +11,7 @@ def updateUser(sender, instance, **kwargs):
 @receiver(post_save, sender=User)
 def create_profile(sender, instance, created, **kwargs):
     if created:
-        Profile.objects.create(user=instance, name=instance.username, email=instance.username)
+        Profile.objects.create(user=instance, name=instance.first_name, email=instance.username)
 
 @receiver(post_save, sender=User)
 def save_profile(sender, instance, **kwargs):


### PR DESCRIPTION
This Pull Request fixes the bug described in issue #173 by modifying the relevant line in the `signals.py` file. The name associated with the Profile is now the name that the user enters while Registering.

If merged, this PR closes #173.